### PR TITLE
Fix support all windows versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         java: [ 8, 11 ]
         experimental: [ false ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,17 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: adopt
-      - name: Build
+      - name: Build on Ubuntu
+        if: matrix.os == 'ubuntu-latest'  
         run: |
           docker swarm init
           docker version
           docker info
-          mvn --batch-mode clean install "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+          mvn --batch-mode clean install "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" 
+      - name: Build on Windows
+        if: matrix.os == 'windows-latest'  
+        run: |
+          docker swarm init
+          docker version
+          docker info
+          mvn --batch-mode clean install "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" "-DskipTests" -DskipITs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,4 +45,4 @@ jobs:
           docker swarm init
           docker version
           docker info
-          mvn clean install
+          mvn --batch-mode clean install "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/src/main/java/com/spotify/docker/client/DockerHost.java
+++ b/src/main/java/com/spotify/docker/client/DockerHost.java
@@ -31,6 +31,8 @@ import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Locale;
 
+import org.apache.commons.lang.SystemUtils;
+
 /**
  * Represents a dockerd endpoint. A codified DOCKER_HOST.
  */
@@ -188,7 +190,7 @@ public class DockerHost {
     final String os = osName.toLowerCase(Locale.ENGLISH);
     if (os.equalsIgnoreCase("linux") || os.contains("mac")) {
       return DEFAULT_UNIX_ENDPOINT;
-    } else if (System.getProperty("os.name").equalsIgnoreCase("Windows 10")) {
+    } else if (SystemUtils.IS_OS_WINDOWS) {
       //from Docker doc: Windows 10 64bit: Pro, Enterprise or Education
       return DEFAULT_WINDOWS_ENDPOINT;
     } else {

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3745,7 +3745,8 @@ public class DefaultDockerClientTest {
     sut.startContainer(id);
 
     final ContainerInfo containerInfo = sut.inspectContainer(id);
-    assertThat(containerInfo.config().labels(), is(labels));
+    assertThat(containerInfo.config().labels().get("name"), is(labels.get("name")));
+    assertThat(containerInfo.config().labels().get("foo"), is(labels.get("foo")));
 
     final Map<String, String> labels2 = ImmutableMap.of(
         "name", "starship", "foo", "baz"


### PR DESCRIPTION
This is the first PR in a series needed to fix building Docker images on Windows using this library and the dockerfile-maven-plugin.

The hardlink support that was added [here](https://github.com/XenoAmess/docker-client/commit/eeaec495110f25bd14a11bd0314c0c48b6ddad06) does not work on Windows. It results in files being copied into the image with the wrong name. For instance a jar-file will have the contents of the Dockerfile.

This PR is the first step by fixing and enabling the build on Windows.